### PR TITLE
Allow for custom server times

### DIFF
--- a/cromUserConfig.txt
+++ b/cromUserConfig.txt
@@ -25,4 +25,10 @@ CROMWELLDBNAME=...
 CROMWELLDBUSERNAME=...
 CROMWELLDBPASSWORD=...
 
+## Number of cores for your Cromwell server itself - usually 4 is sufficient.  
+###Increase if you want to run many, complex workflows simlutaneously or notice your server is slowing down.
 NCORES=4
+## Length of time you want the server to run for.  
+### Note: when servers go down, all jobs they'd sent will continue.  When you start up a server the next time
+### using the same database, the new server will pick up whereever the previous workflows left off.  "7-0" is 7 days, zero hours.
+SERVERTIME="7-0" 

--- a/cromwell.sh
+++ b/cromwell.sh
@@ -4,7 +4,7 @@ if [ ! -f ${1} ]; then
   exit
 fi
 source ${1}
-if [[ -z $NCORES || -z $SCRATCHDIR || -z $WORKFLOWLOGDIR || -z $WORKFLOWOUTPUTSDIR || -z $SERVERLOGDIR || -z $CROMWELLDBPORT || -z $CROMWELLDBNAME || -z $CROMWELLDBUSERNAME || -z $CROMWELLDBPASSWORD ]]; then 
+if [[ -z $NCORES || -z $SCRATCHDIR || -z $WORKFLOWLOGDIR || -z $WORKFLOWOUTPUTSDIR || -z $SERVERLOGDIR || -z $CROMWELLDBPORT || -z $CROMWELLDBNAME || -z $CROMWELLDBUSERNAME || -z $CROMWELLDBPASSWORD || -z $SERVERTIME ]]; then 
     echo "One or more of your personal configuration variables is unset, please check your configuration file and try again."
     exit 1
 fi
@@ -23,7 +23,7 @@ fi
 
 echo "Requesting resources from SLURM for your server..."
 # Submit the server job, and tell it to send netcat info back to port 6000
-sbatch --export=MYPORT=6000 --cpus-per-task=$NCORES -N 1 --time="7-0" --job-name="cromwellServer" \
+sbatch --export=MYPORT=6000 --cpus-per-task=$NCORES -N 1 --time=$SERVERTIME --job-name="cromwellServer" \
   --output=$SERVERLOGDIR/cromwell_%A.out\
   ./diy-cromwell-server/cromwellServer.sh ./diy-cromwell-server/fh-S3-cromwell.conf \
   ${1}

--- a/cromwell.sh
+++ b/cromwell.sh
@@ -4,11 +4,15 @@ if [ ! -f ${1} ]; then
   exit
 fi
 source ${1}
-if [[ -z $NCORES || -z $SCRATCHDIR || -z $WORKFLOWLOGDIR || -z $WORKFLOWOUTPUTSDIR || -z $SERVERLOGDIR || -z $CROMWELLDBPORT || -z $CROMWELLDBNAME || -z $CROMWELLDBUSERNAME || -z $CROMWELLDBPASSWORD || -z $SERVERTIME ]]; then 
+if [[ -z $NCORES || -z $SCRATCHDIR || -z $WORKFLOWLOGDIR || -z $WORKFLOWOUTPUTSDIR || -z $SERVERLOGDIR || -z $CROMWELLDBPORT || -z $CROMWELLDBNAME || -z $CROMWELLDBUSERNAME || -z $CROMWELLDBPASSWORD ]]; then 
     echo "One or more of your personal configuration variables is unset, please check your configuration file and try again."
     exit 1
 fi
 echo "Your configuration details have been found..."
+# Setting default servertime if not specified
+if [[ -z $SERVERTIME ]]; then 
+  SERVERTIME="7-0"
+fi
 
 echo "Getting an updated copy of Cromwell configs from GitHub..."
 # If the repo already exists, delete it then re-clone a fresh copy

--- a/fh-S3-cromwell.conf
+++ b/fh-S3-cromwell.conf
@@ -133,7 +133,7 @@ backend {
               -e ${cwd}/execution/stderr \
               --cpus-per-task=${cpu} \
               --time=${walltime} \
-              --wrap "singularity exec --containall --bind ${cwd}:${docker_cwd} $IMAGE ${job_shell} ${docker_script}"
+              --wrap "singularity exec --containall --bind ${cwd}:${docker_cwd} --bind $HOME $IMAGE ${job_shell} ${docker_script}"
         """
        filesystems {
           local {


### PR DESCRIPTION
Previously the duration of Cromwell server jobs was hardcoded.  Now it's up to the user to configure, or it will set it to be the default of 7 days.  