### PR TITLE
Add flock locking for singularity pull in docker backend

### DIFF
--- a/fh-S3-cromwell.conf
+++ b/fh-S3-cromwell.conf
@@ -41,12 +41,17 @@ workflow-options {
 }
 akka.http.server.request-timeout = 60s
 call-caching {
-  # Allows re-use of existing results for jobs you've already run (default: false)
+
+  # Allows re-use of existing results for jobs you've already run (default:
+  # false)
+
   enabled = true
 
-  # Whether to invalidate a cache result forever if we cannot reuse them. Disable this if you expect some cache copies
-  # to fail for external reasons which should not invalidate the cache (e.g. auth differences between users):
-  # (default: true)
+  # Whether to invalidate a cache result forever if we cannot reuse them.
+  # Disable this if you expect some cache copies to fail for external reasons
+  # which should not invalidate the cache (e.g. auth differences between
+  # users): (default: true)
+
   invalidate-bad-cache-results = true
 }
 aws {
@@ -145,14 +150,25 @@ backend {
 
             # Ensure singularity is loaded if it's installed as a module
             module load Singularity/3.5.3
+
             # Build the Docker image into a singularity image
             DOCKER_NAME=$(sed -e 's/[^A-Za-z0-9._-]/_/g' <<< ${docker})
-            # The image will live together with all the other images to force "caching" of the .sif files themselves - note, always use docker hub tags!!!
+
+            # The image will live together with all the other images to force
+            # "caching" of the .sif files themselves - note, always use docker
+            # hub tags!!!
             IMAGE=$SINGULARITYCACHEDIR/$DOCKER_NAME.sif
 
-            if [ ! -f $IMAGE ]; then  # If we already have the image, skip everything
-                singularity pull $IMAGE docker://${docker}
-            fi   
+            if [ -z $SINGULARITYCACHEDIR ];
+            then
+              CACHE_DIR=$HOME/.singularity/cache
+            else
+              CACHE_DIR=$SINGULARITYCACHEDIR
+            fi
+
+            LOCK_FILE=$CACHE_DIR/singularity_pull_flock
+            flock --verbose --exclusive --timeout 900 $LOCK_FILE \
+              singularity exec --containall docker://${docker} echo "succesfully pulled ${docker}!"
 
             # Submit the script to SLURM
             sbatch \


### PR DESCRIPTION
This worked for me.  Based of the work [here](https://github.com/broadinstitute/cromwell/issues/5063) with some modifications.  I'm concerned that there could be collisions between different workflows that all attempt to pull the same image, but that might be unlikely.